### PR TITLE
Fixes to headings, WIP, refs #19

### DIFF
--- a/src/css/markdown.css
+++ b/src/css/markdown.css
@@ -16,10 +16,18 @@
 .hack strong,
 .hack code {
   font-size: 1rem;
-  line-height: 20px;
   font-style: normal;
   font-family: Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
 }
+
+.hack code,
+.hack blockquote,
+.hack em,
+.hack strong,
+.hack code {
+  line-height: 20px;
+}
+
 .hack h1,
 .hack h2,
 .hack h3,
@@ -72,17 +80,16 @@
   position: relative;
   margin-bottom: 1.75rem;
 }
-.hack h1,
-.hack h2 {
-  line-height: 30px;
-}
+
 .hack h2:before,
 .hack h3:before,
 .hack h4:before,
 .hack h5:before,
 .hack h6:before {
-  content: "## ";
   display: inline;
+}
+.hack h2:before {
+  content: "## ";
 }
 .hack h3:before {
   content: "### ";

--- a/src/css/markdown.css
+++ b/src/css/markdown.css
@@ -3,9 +3,6 @@
  * with some modifications
  */
 
-.hack {
-  word-wrap: break-word;
-}
 .hack,
 .hack h1,
 .hack h2,

--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -12,6 +12,7 @@ body {
   line-height: 1.5rem;
   margin: 0;
   font-family: Menlo,Monaco,Lucida Console,Liberation Mono,DejaVu Sans Mono,Bitstream Vera Sans Mono,Courier New,monospace,serif;
+  word-wrap: break-word;
 }
 
 fieldset {

--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -15,6 +15,10 @@ body {
   word-wrap: break-word;
 }
 
+h1, h2, h3, h4, h5, h6 {
+  line-height: 1.3em;
+}
+
 fieldset {
   border: none;
   padding: 0;

--- a/src/css/standard.css
+++ b/src/css/standard.css
@@ -1,12 +1,3 @@
-.standard h1,
-.standard h2,
-.standard h3,
-.standard h4,
-.standard h5,
-.standard h6 {
-  line-height: 1.3em;
-}
-
 .standard h1 {
   font-size: 2em;
   font-weight: bold;

--- a/src/css/standard.css
+++ b/src/css/standard.css
@@ -1,3 +1,12 @@
+.standard h1,
+.standard h2,
+.standard h3,
+.standard h4,
+.standard h5,
+.standard h6 {
+  line-height: 1.3em;
+}
+
 .standard h1 {
   font-size: 2em;
   font-weight: bold;


### PR DESCRIPTION
There are several changes that I made:
1. Removed `.hack { word-wrap: break-word; }` rule, placed this rule inside `body`
2. Set `line-height: 1.3em` to all the headers, which fixes the #19 issue

Does `1.3em` look good to you? Any other comments?