### PR TITLE
Added `standard` mode to the main page. refs #11

### DIFF
--- a/src/html/index.jade
+++ b/src/html/index.jade
@@ -15,7 +15,7 @@ html
 
       p As you can see, this website is proudly built using hack.css.
 
-      .alert.alert-info New! <a href="/dark.html">dark mode</a> is now available!
+      .alert.alert-info New! <a href="/dark.html">dark</a> and <a href="/standard.html">standard</a> modes are now available!
 
       h2 About
 

--- a/src/html/standard.jade
+++ b/src/html/standard.jade
@@ -1,0 +1,35 @@
+doctype html
+html
+  head
+    meta(charset="utf-8")
+    meta(http-equiv="X-UA-Compatible" content="IE=edge")
+    meta(name="viewport" content="width=device-width, initial-scale=1")
+    title standard mode of hack.css
+    link(rel="stylesheet" href="./prism.css")
+    link(rel="stylesheet" href="./hack.css?t=#{time}")
+    link(rel="stylesheet" href="./standard.css?t=#{time}")
+    link(rel="stylesheet" href="./site.css?t=#{time}")
+
+  body.standard
+    .main.container
+      p
+        a(href="/") &laquo; Back to home
+      h2 Standard mode
+      p Lorem ipsum dolor sit amet, consectetur adipisicing elit. Sint vero maiores quam culpa sed, dolor delectus omnis ab repellat dolorum, atque obcaecati inventore ex ratione hic numquam quia, iste necessitatibus.
+
+      h2 Usage
+      :marked
+        ```html
+        <link rel="stylesheet" href="/path/to/hack.css" />
+        <link rel="stylesheet" href="/path/to/standard.css" />
+        <body class="standard">
+          ...
+        </body>
+        ```
+
+      h2 Components
+
+      include components
+
+      script(src="./prism.js" async)
+      script(src="./app.js" async)


### PR DESCRIPTION
Changes:
1. Added `standard.jade` template, with pretty much the same content as `dark` mode has
2. Added link from the main page the `standard` mode