### PR TITLE
Fixed unwanted line break in progress bar

### DIFF
--- a/src/css/components.css
+++ b/src/css/components.css
@@ -32,6 +32,7 @@
     content: attr(data-filled);
     display: block;
     font-size: 12px;
+    white-space: nowrap;
     position: absolute;
     border: 6px solid transparent;
     top: -38px;


### PR DESCRIPTION
The percentage indicator above the progress bar has an unwanted line break for lower values.

**Currently**
![1](https://cloud.githubusercontent.com/assets/236774/18393572/3888a886-76b6-11e6-9d71-ae62199baaf6.png)
![2](https://cloud.githubusercontent.com/assets/236774/18393574/38c22ad4-76b6-11e6-83a5-342300d5b672.png)

**Changed**
![3](https://cloud.githubusercontent.com/assets/236774/18393573/3889fe02-76b6-11e6-8527-c18e4901f738.png)
