### PR TITLE
Fix broken progress bar documentation

### DIFF
--- a/src/html/components.jade
+++ b/src/html/components.jade
@@ -136,8 +136,8 @@ h4 Progress bar
   </div>
 
   <!-- with a percentage showing above the arrow -->
-  <div class="progress-bar progress-bar-show-percent" data-filled="Loading 40%">
-    <div class="progress-bar-filled" style="width: 40%"></div>
+  <div class="progress-bar progress-bar-show-percent">
+    <div class="progress-bar-filled" style="width: 40%" data-filled="Loading 40%"></div>
   </div>
   ```
 


### PR DESCRIPTION
The documentation didn't match the actual implementation.

Progress bars need the `data-filled` attribute on the child not the parent element.